### PR TITLE
Reduce log output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 /build/
 /.idea
 *.iml
+/.classpath
+/.project
+/bin
+/.settings

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,24 @@
-/.gradle/
+########################################
+# OS generated files 
+########################################
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+#Icon?
+ehthumbs.db
+Thumbs.db
+*~
+
+########################################
+# Eclipse, Gradle, Build Products
+########################################
+/bin
 /build/
+/.gradle/
 /.idea
 *.iml
 /.classpath
 /.project
-/bin
 /.settings

--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,15 @@ applicationDistribution.from(extractDocbookXml) {
   into "docbook/xml-dtd-4.5"
 }
 
+task copyLoggingConfig(type: Copy) {
+	from "logging.properties"
+	into file("$buildDir/logging/")
+}
+
+applicationDistribution.from(copyLoggingConfig) {
+	into "."
+}
+
 CreateStartScripts startScripts = project.startScripts
 startScripts.with {
   doLast {

--- a/build.gradle
+++ b/build.gradle
@@ -28,8 +28,7 @@ dependencies {
 }
 
 mainClassName = 'org.apache.fop.cli.Main'
-applicationDefaultJvmArgs = ['-Dxml.catalog.files=APP_DIR/catalog.xml']
-//applicationDefaultJvmArgs = ['-Dxml.catalog.files=/etc/xml/catalog']
+applicationDefaultJvmArgs = ['-Dxml.catalog.files=APP_DIR/catalog.xml', '-Djava.util.logging.config.file=APP_DIR/logging.properties']
 
 installApp {
   destinationDir = file("$buildDir/${project.name}")
@@ -75,7 +74,7 @@ applicationDistribution.from(copyLoggingConfig) {
 CreateStartScripts startScripts = project.startScripts
 startScripts.with {
   doLast {
-    unixScript.text = unixScript.text.replaceFirst('APP_DIR', '\\$APP_DIR')
-    windowsScript.text = windowsScript.text.replaceFirst('APP_DIR', '%APP_HOME%')
+    unixScript.text = unixScript.text.replaceAll('APP_DIR', '\\$APP_DIR')
+    windowsScript.text = windowsScript.text.replaceAll('APP_DIR', '%APP_HOME%')
   }
 }

--- a/fopub
+++ b/fopub
@@ -134,6 +134,8 @@ case $FORMAT in
   ;;
 esac
 
+export FOPUB_OPTS="-Djava.util.logging.config.file=$APP_DIR/logging.properties"
+
 eval $FOPUB_CMD -q -catalog \
   -c \"$DOCBOOK_XSL_DIR/fop-config.xml\" \
   $CONVERT_ARGS \

--- a/fopub
+++ b/fopub
@@ -136,6 +136,10 @@ esac
 
 export FOPUB_OPTS="-Djava.util.logging.config.file=$APP_DIR/logging.properties"
 
+echo ""
+echo "########## PDF conversion started, please be patient, fellow human... ###########"
+echo ""
+
 eval $FOPUB_CMD -q -catalog \
   -c \"$DOCBOOK_XSL_DIR/fop-config.xml\" \
   $CONVERT_ARGS \

--- a/fopub
+++ b/fopub
@@ -134,8 +134,6 @@ case $FORMAT in
   ;;
 esac
 
-export FOPUB_OPTS="-Djava.util.logging.config.file=$APP_DIR/logging.properties"
-
 echo ""
 echo "########## PDF conversion started, please be patient, fellow human... ###########"
 echo ""

--- a/fopub
+++ b/fopub
@@ -135,7 +135,7 @@ case $FORMAT in
 esac
 
 echo ""
-echo "########## PDF conversion started, please be patient, fellow human... ###########"
+echo "########## PDF conversion started, please be patient... ###########"
 echo ""
 
 eval $FOPUB_CMD -q -catalog \

--- a/fopub.bat
+++ b/fopub.bat
@@ -62,6 +62,8 @@ set DOCBOOK_DIR_PARAM=file:///%DOCBOOK_DIR%
 set DOCBOOK_DIR_PARAM=!DOCBOOK_DIR_PARAM:\=/!
 set XSLTHL_CONFIG_URI=!XSLTHL_CONFIG_URI:\=/!
 
+SET FOPUB_OPTS="-Djava.util.logging.config.file=$APP_DIR\logging.properties"
+
 if "%TYPE%" == "pdf" (
   set OUTPUT_PDF_FILE="%SOURCE_ROOTNAME%.pdf"
   %FOPUB_CMD% -q -catalog -c "%DOCBOOK_XSL_DIR%\fop-config.xml" -xml "%SOURCE_FILE%" -xsl "%DOCBOOK_XSL_DIR%\fo-pdf.xsl" -pdf !OUTPUT_PDF_FILE! -param highlight.xslthl.config "%XSLTHL_CONFIG_URI%" -param admon.graphics.path "%DOCBOOK_DIR_PARAM%/images/" -param callout.graphics.path "%DOCBOOK_DIR_PARAM%/images/callouts/"

--- a/fopub.bat
+++ b/fopub.bat
@@ -62,8 +62,6 @@ set DOCBOOK_DIR_PARAM=file:///%DOCBOOK_DIR%
 set DOCBOOK_DIR_PARAM=!DOCBOOK_DIR_PARAM:\=/!
 set XSLTHL_CONFIG_URI=!XSLTHL_CONFIG_URI:\=/!
 
-SET FOPUB_OPTS="-Djava.util.logging.config.file=$APP_DIR\logging.properties"
-
 echo .
 echo "########## PDF conversion started, please be patient, fellow human... ###########"
 echo .

--- a/fopub.bat
+++ b/fopub.bat
@@ -64,6 +64,10 @@ set XSLTHL_CONFIG_URI=!XSLTHL_CONFIG_URI:\=/!
 
 SET FOPUB_OPTS="-Djava.util.logging.config.file=$APP_DIR\logging.properties"
 
+echo .
+echo "########## PDF conversion started, please be patient, fellow human... ###########"
+echo .
+
 if "%TYPE%" == "pdf" (
   set OUTPUT_PDF_FILE="%SOURCE_ROOTNAME%.pdf"
   %FOPUB_CMD% -q -catalog -c "%DOCBOOK_XSL_DIR%\fop-config.xml" -xml "%SOURCE_FILE%" -xsl "%DOCBOOK_XSL_DIR%\fo-pdf.xsl" -pdf !OUTPUT_PDF_FILE! -param highlight.xslthl.config "%XSLTHL_CONFIG_URI%" -param admon.graphics.path "%DOCBOOK_DIR_PARAM%/images/" -param callout.graphics.path "%DOCBOOK_DIR_PARAM%/images/callouts/"

--- a/fopub.bat
+++ b/fopub.bat
@@ -63,7 +63,7 @@ set DOCBOOK_DIR_PARAM=!DOCBOOK_DIR_PARAM:\=/!
 set XSLTHL_CONFIG_URI=!XSLTHL_CONFIG_URI:\=/!
 
 echo .
-echo "########## PDF conversion started, please be patient, fellow human... ###########"
+echo "########## PDF conversion started, please be patient... ###########"
 echo .
 
 if "%TYPE%" == "pdf" (

--- a/logging.properties
+++ b/logging.properties
@@ -1,0 +1,8 @@
+handlers=java.util.logging.ConsoleHandler
+.level=WARNING
+
+java.util.logging.ConsoleHandler.level = INFO
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+java.util.logging.SimpleFormatter.format=fopub  : %4$s: %5$s%n
+
+org.apache.fop.events.LoggingEventListener.level=WARNING


### PR DESCRIPTION
This adds a JDK logging configuration file that reduces the log output of fopub to only show warnings and above. Furthermore, the output is condensed a bit.